### PR TITLE
Make doctest explicitly enumerate the packages it uses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,8 @@ install:
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
      cabal install --only-dependencies --enable-tests --enable-benchmarks;
+     if [[ "$GHCVER" = "7.10.1" || "$GHCVER" = "7.10.2" ]]; then cabal install Cabal-1.22.5.0; fi;
+     if [ "$GHCVER" = "7.10.3" ]; then cabal install Cabal-1.22.4.0; fi;
    fi
 
 # snapshot package-db on cache miss

--- a/distribution-nixpkgs.cabal
+++ b/distribution-nixpkgs.cabal
@@ -13,7 +13,7 @@ maintainer:     Peter Simons <simons@cryp.to>
 license:        BSD3
 license-file:   LICENSE
 tested-with:    GHC > 7.10 && < 8.1
-build-type:     Simple
+build-type:     Custom
 cabal-version:  >= 1.10
 
 source-repository head

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,5 +1,6 @@
 module Main ( main ) where
 
+import Build_spec (deps)
 import Control.DeepSeq
 import Control.Exception
 import Control.Lens
@@ -14,7 +15,11 @@ main :: IO ()
 main = do
   distDir <- fromMaybe "dist" `fmap` lookupEnv "HASKELL_DIST_DIR"
   let cabalMacrosHeader = distDir ++ "/build/autogen/cabal_macros.h"
-  doctest [ "-isrc", "-optP-include", "-optP"++cabalMacrosHeader, "src" ]
+  doctest $ [ "-isrc"
+            , "-optP-include"
+            , "-optP"++cabalMacrosHeader
+            , "-hide-all-packages"
+            ] ++ map ("-package="++) deps ++ ["src"]
 
   hspec $
     describe "DeepSeq instances work properly for" $ do


### PR DESCRIPTION
Currently, this package's `doctest` tests look up module names among all globally installed packages, which can lead to problems like in https://github.com/fpco/stackage/issues/1616. This PR fixes it by passing `doctest` the `-hide-all-packages` flag and using `-package` to explicitly enumerate each package that `distribution-nixpkgs` depends on, and no more.