### PR TITLE
relax Cabal version constraint

### DIFF
--- a/distribution-nixpkgs.cabal
+++ b/distribution-nixpkgs.cabal
@@ -28,7 +28,7 @@ library
       aeson
     , base > 4.2 && < 5
     , bytestring
-    , Cabal > 1.24
+    , Cabal >= 1.24
     , containers
     , deepseq >= 1.4
     , language-nix > 2
@@ -55,7 +55,7 @@ test-suite spec
       aeson
     , base > 4.2 && < 5
     , bytestring
-    , Cabal > 1.24
+    , Cabal >= 1.24
     , containers
     , deepseq >= 1.4
     , language-nix > 2


### PR DESCRIPTION
https://hackage.haskell.org/package/Cabal claims there to be no version of `Cabal` numbered greater than `1.24.0.0` at the moment.