### PR TITLE
GHC 8.4 compat

### DIFF
--- a/src/Distribution/Nixpkgs/Meta.hs
+++ b/src/Distribution/Nixpkgs/Meta.hs
@@ -24,6 +24,7 @@ import GHC.Generics ( Generic )
 import Internal.OrphanInstances ( )
 import Language.Nix.Identifier
 import Language.Nix.PrettyPrinting
+import Prelude hiding ((<>))
 
 -- | A representation of the @meta@ section used in Nix expressions.
 --

--- a/src/Internal/OrphanInstances.hs
+++ b/src/Internal/OrphanInstances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Internal.OrphanInstances ( ) where
@@ -5,6 +6,9 @@ module Internal.OrphanInstances ( ) where
 import Control.DeepSeq
 import Distribution.System
 
+-- This is needed for GHC 8.4+, due to new Cabal
+#if !MIN_VERSION_base(4,11,0)
 instance NFData Arch
 instance NFData OS
 instance NFData Platform
+#endif

--- a/src/Language/Nix/PrettyPrinting.hs
+++ b/src/Language/Nix/PrettyPrinting.hs
@@ -22,6 +22,7 @@ import Data.List
 import Data.Set ( Set )
 import qualified Data.Set as Set
 import Distribution.Text ( Text, disp )
+import Prelude hiding ((<>))
 import "pretty" Text.PrettyPrint.HughesPJClass
 
 attr :: String -> Doc -> Doc


### PR DESCRIPTION
1. Keep `<>` to refer to `Text.PrettyPrint.HughesPJ.<>`
2. Cabal 2 defines instances some new instances for us