### PR TITLE
Use lib instead of stdenv.lib

### DIFF
--- a/src/Distribution/Nixpkgs/License.hs
+++ b/src/Distribution/Nixpkgs/License.hs
@@ -14,19 +14,19 @@ import GHC.Generics ( Generic )
 import Language.Nix.PrettyPrinting
 
 -- | The representation for licenses used in Nix derivations. Known
--- licenses are Nix expressions -- such as @stdenv.lib.licenses.bsd3@
+-- licenses are Nix expressions -- such as @lib.licenses.bsd3@
 -- --, so their exact \"name\" is not generally known, because the path
--- to @stdenv@ depends on the context defined in the expression. In
+-- to @lib@ depends on the context defined in the expression. In
 -- Cabal expressions, for example, the BSD3 license would have to be
--- referred to as @self.stdenv.lib.licenses.bsd3@. Other expressions,
+-- referred to as @self.lib.licenses.bsd3@. Other expressions,
 -- however, use different paths to the @licenses@ record. Because of tat
 -- situation, the library cannot provide an abstract data type that
 -- encompasses all known licenses. Instead, the @License@ type just
 -- distinguishes references to known and unknown licenses. The
 -- difference between the two is in the way they are pretty-printed:
 --
--- > > putStrLn (display (Known "stdenv.lib.license.gpl2"))
--- > stdenv.lib.license.gpl2
+-- > > putStrLn (display (Known "lib.license.gpl2"))
+-- > lib.license.gpl2
 -- >
 -- > > putStrLn (display (Unknown (Just "GPL")))
 -- > "GPL"

--- a/src/Distribution/Nixpkgs/Meta.hs
+++ b/src/Distribution/Nixpkgs/Meta.hs
@@ -43,8 +43,8 @@ import Language.Nix.PrettyPrinting
 -- description = "an example package";
 -- license = "unknown";
 -- platforms = [ "x86_64-linux" ];
--- hydraPlatforms = stdenv.lib.platforms.none;
--- maintainers = with stdenv.lib.maintainers; [ jane joe ];
+-- hydraPlatforms = lib.platforms.none;
+-- maintainers = with lib.maintainers; [ jane joe ];
 -- broken = true;
 
 data Meta = Meta
@@ -69,13 +69,13 @@ instance Pretty Meta where
     , attr "license" $ pPrint _license
     , onlyIf (_platforms /= allKnownPlatforms) $ renderPlatforms "platforms" _platforms
     , onlyIf (_hydraPlatforms /= _platforms) $ renderPlatforms "hydraPlatforms" _hydraPlatforms
-    , setattr "maintainers" (text "with stdenv.lib.maintainers;") (Set.map (view ident) _maintainers)
+    , setattr "maintainers" (text "with lib.maintainers;") (Set.map (view ident) _maintainers)
     , boolattr "broken" _broken _broken
     ]
 
 renderPlatforms :: String -> Set Platform -> Doc
 renderPlatforms field ps
-  | Set.null ps = sep [ text field <+> equals <+> text "stdenv.lib.platforms.none" <> semi ]
+  | Set.null ps = sep [ text field <+> equals <+> text "lib.platforms.none" <> semi ]
   | otherwise   = sep [ text field <+> equals <+> lbrack
                       , nest 2 $ fsep $ map text (toAscList (Set.map fromCabalPlatform ps))
                       , rbrack <> semi


### PR DESCRIPTION
In Nixpkgs stdenv.lib is deprecated[1] and may be removed in the future.

[1]: https://github.com/NixOS/nixpkgs/issues/108938