### PR TITLE
Add support for the aarch64-linux platform

### DIFF
--- a/distribution-nixpkgs.cabal
+++ b/distribution-nixpkgs.cabal
@@ -24,7 +24,7 @@ library
                       Language.Nix.PrettyPrinting
   hs-source-dirs:     src
   build-depends:      base         > 4.2 && < 5
-                    , Cabal        > 2.2
+                    , Cabal        >= 2.4
                     , aeson
                     , bytestring
                     , containers

--- a/src/Distribution/Nixpkgs/Meta.hs
+++ b/src/Distribution/Nixpkgs/Meta.hs
@@ -95,6 +95,7 @@ nullMeta = Meta
 allKnownPlatforms :: Set Platform
 allKnownPlatforms = Set.fromList [ Platform I386 Linux, Platform X86_64 Linux
                                  , Platform X86_64 OSX, Platform (OtherArch "armv7l") Linux
+                                 , Platform AArch64 Linux
                                  ]
 
 fromCabalPlatform :: Platform -> String
@@ -102,4 +103,5 @@ fromCabalPlatform (Platform I386 Linux)                 = "\"i686-linux\""
 fromCabalPlatform (Platform X86_64 Linux)               = "\"x86_64-linux\""
 fromCabalPlatform (Platform X86_64 OSX)                 = "\"x86_64-darwin\""
 fromCabalPlatform (Platform (OtherArch "armv7l") Linux) = "\"armv7l-linux\""
+fromCabalPlatform (Platform AArch64 Linux)              = "\"aarch64-linux\""
 fromCabalPlatform p                                     = error ("fromCabalPlatform: invalid Nix platform" ++ show p)


### PR DESCRIPTION
Part of a fix for https://github.com/NixOS/nixpkgs/issues/116095

See also https://github.com/NixOS/cabal2nix/pull/485