### PR TITLE
Collect all attributes pointing to (the same) derivations

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -45,6 +45,13 @@ jobs:
           apt-get install -y $CC cabal-install-3.4
         env:
           CC: ${{ matrix.compiler }}
+      - name: Prerequisites for install-nix-action
+        run: |
+          apt-get install -y --no-install-recommends sudo
+          echo "USER=$(whoami)" >> $GITHUB_ENV
+      - uses: cachix/install-nix-action@v13
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/83d907fd760d9ee4f49b4b7e4b1c6682f137b573.tar.gz
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
@@ -143,6 +150,7 @@ jobs:
         run: |
           PKGDIR_distribution_nixpkgs="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/distribution-nixpkgs-[0-9.]*')"
           echo "PKGDIR_distribution_nixpkgs=${PKGDIR_distribution_nixpkgs}" >> $GITHUB_ENV
+          echo "distribution_nixpkgs_datadir=${PKGDIR_distribution_nixpkgs}" >> $GITHUB_ENV
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_distribution_nixpkgs}" >> cabal.project

--- a/src/Distribution/Nixpkgs/PackageMap.hs
+++ b/src/Distribution/Nixpkgs/PackageMap.hs
@@ -28,8 +28,7 @@ type PackageMap = Map Identifier (Set Path)
 --   Note: Evaluation of nixpkgs is very expensive (takes multiple
 --   seconds), so cache the result of this function if possible.
 --
---   >>> readNixpkgPackageMap "<nixpkgs>" (Just "{ config = { allowAliases = false; }; }")
---   fromList [ … ]
+--   >>> nixpkgs <- readNixpkgPackageMap "<nixpkgs>" (Just "{ config = { allowAliases = false; }; }")
 readNixpkgPackageMap :: String
                      -- ^ Path to nixpkgs, must be a valid nix path
                      --   (absolute, relative or @NIX_PATH@ lookup)
@@ -77,6 +76,7 @@ parsePackage x
 -- | Finds the shortest 'Path' in a 'PackageMap' that has the
 --   given 'Identifier' as its last component.
 --
+--   >>> nixpkgs <- readNixpkgPackageMap "<nixpkgs>" Nothing
 --   >>> resolve nixpkgs (ident # "pam")
 --   Just (Bind (Identifier "pam") (Path [Identifier "pam"]))
 resolve :: PackageMap -> Identifier -> Maybe Binding


### PR DESCRIPTION
This pull request aims to fix #9 which describes a concrete problem pretty well.

I think this is the best way forward even though it requires us to have a quite considerable part of the internal implementation in pure nix instead of using `nix-env`. I think this is okay:

* It is unclear how long `nix-env` will stay in light of Nix 2.4 or 3.0. `nix-instantiate` however will be easy to replace by `nix eval` in the future.
* `distribution-nixpkgs` and its main user match on *attribute* names exclusively. This is the opposite of the approach of `nix-env` which matches on *unique derivations* and their meta data. Therefore its handling of attribute names is poor.
* `builtins.tryEval` is a bit dangerous, but okay for nixpkgs: ofborg uses tryEval for evaluation checks as well, so there should never be a situation where `distribution-nixpkgs` can't cope with nixpkgs and nixpkgs's CI is green.

Breaking the API is okay in my opinion because I'll send a PR adjusting `distribution-nixpkgs`'s main user: `hackage2nix`. `stackage2nix` is deprecated and `stack2nix` pins `distribution-nixpkgs` to `< 1.3` (and is broken in nixpkgs).

More details on implementation are in the first commit message which I'll copy here:

`nix-env` evaluates nixpkgs and prints a collection of *derivations*
with additional meta data (like name, attribute path, description, …).
Derivations are uniquely identified via their `outPath`, so `nix-env`
will by design only return one entry *per derivation*. This is
undesireable in the case of `resolve` where we try to match on the
*attribute name*. `nix-env` fails us here if there are multiple
attribute names for a single derivation: In such cases it only prints
the one that comes first alphabetically.

For example when resolving `pam`, `resolve` would previously return
`python38Packages.pam` despite obviously just `pam` would be correct.
This is caused by `pam` and `linux-pam` evaluating to the same
derivation on Linux and `nix-env` printing only `linux-pam`
consequently.

To fix this we employ a relatively simple nix expression which takes a
path to nixpkgs and optional arguments to pass to it and returns a list
of all attribute paths which point to a derivation. In doing that it
also respects the rules surrounding `recurseForDerivations`.

This also greatly simplifies the parsing code since we no longer need to
split and parse the attribute paths. Also there is a significant speedup
of ~125% (on my laptop) since we don't need to compute any `outPath`s.

However, we are forced to use `nix-instantiate` instead of `nix-env` for
this which supports different flags. Thus we can't really keep the
`extraArgs` approach we had previously. `readNixpkgPackageMap` now
expects a (nix) path to nixpkgs and optionally a attribute set to pass
to nixpkgs as an argument. The version number has been increased to
1.6.0 as a result.
